### PR TITLE
Fix boot loader when "$disk" is defined

### DIFF
--- a/debi.sh
+++ b/debi.sh
@@ -745,8 +745,13 @@ popularity-contest popularity-contest/participate boolean false
 
 # Boot loader installation
 
-d-i grub-installer/bootdev string default
 EOF
+
+if [ -n "$disk" ]; then
+        echo "d-i grub-installer/bootdev string $disk" | $save_preseed
+else
+        echo 'd-i grub-installer/bootdev string default' | $save_preseed
+fi
 
 [ "$force_efi_extra_removable" = true ] && echo 'd-i grub-installer/force-efi-extra-removable boolean true' | $save_preseed
 [ -n "$kernel_params" ] && echo "d-i debian-installer/add-kernel-opts string$kernel_params" | $save_preseed

--- a/debi.sh
+++ b/debi.sh
@@ -748,9 +748,9 @@ popularity-contest popularity-contest/participate boolean false
 EOF
 
 if [ -n "$disk" ]; then
-        echo "d-i grub-installer/bootdev string $disk" | $save_preseed
+    echo "d-i grub-installer/bootdev string $disk" | $save_preseed
 else
-        echo 'd-i grub-installer/bootdev string default' | $save_preseed
+    echo 'd-i grub-installer/bootdev string default' | $save_preseed
 fi
 
 [ "$force_efi_extra_removable" = true ] && echo 'd-i grub-installer/force-efi-extra-removable boolean true' | $save_preseed


### PR DESCRIPTION
机器有两个盘：/dev/sda 和 /dev/vda ，添加参数--disk /dev/vda将系统安装至该盘，grub也需要安装至该盘，否则grub-install会出错。