### PR TITLE
Force lowmem (fix #45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Otherwise, you can run this command to revert all changes made by the script:
  * `--firmware` Load additional [non-free firmwares](https://wiki.debian.org/Firmware#Firmware_during_the_installation)
  * `--no-force-efi-extra-removable` [See](https://wiki.debian.org/UEFI#Force_grub-efi_installation_to_the_removable_media_path)
  * `--grub-timeout 5` How many seconds the GRUB menu shows before entering the installer
+ * `--force-lowmem <integer>` Valid values: 0, 1, 2. Force [low memory level](https://salsa.debian.org/installer-team/lowmem). Useful if your machine has memory less than 500M where level 2 is set (see issue #45). `--force-lowmem 1` may solve it. 
  * `--dry-run` Print generated preseed and GRUB entry without downloading the installer and actually saving them
 
 ### Presets

--- a/debi.sh
+++ b/debi.sh
@@ -828,7 +828,7 @@ installer_directory=$(grub2-mkrelpath "$mkrelpath" 2> /dev/null) || {
 
 kernel_params="$kernel_params lowmem/low=1"
 
-[ -n "$force_lowmem" ] && kernel_params="$kernel_params lowmem/low=1 lowmem=+$force_lowmem"
+[ -n "$force_lowmem" ] && kernel_params="$kernel_params lowmem=+$force_lowmem"
 
 initrd="$installer_directory/initrd.gz"
 [ "$firmware" = true ] && initrd="$initrd $installer_directory/firmware.cpio.gz"

--- a/debi.sh
+++ b/debi.sh
@@ -228,6 +228,7 @@ install_recommends=true
 install='ca-certificates libpam-systemd'
 upgrade=
 kernel_params=
+force_lowmem=
 bbr=false
 ssh_port=
 hold=false
@@ -347,6 +348,11 @@ while [ $# -gt 0 ]; do
             ;;
         --no-part|--no-disk-partitioning)
             disk_partitioning=false
+            ;;
+        --force-lowmem)
+            [ "$2" != 0 ] && [ "$2" != 1 ] && [ "$2" != 2 ] && err 'Low memory level can only be 0, 1 or 2'
+            force_lowmem=$2
+            shift
             ;;
         --disk)
             disk=$2
@@ -821,6 +827,8 @@ installer_directory=$(grub2-mkrelpath "$mkrelpath" 2> /dev/null) || {
 [ "$dry_run" = true ] && installer_directory="$installer_directory/debian-$suite"
 
 kernel_params="$kernel_params lowmem/low=1"
+
+[ -n "$force_lowmem" ] && kernel_params="$kernel_params lowmem/low=1 lowmem=+$force_lowmem"
 
 initrd="$installer_directory/initrd.gz"
 [ "$firmware" = true ] && initrd="$initrd $installer_directory/firmware.cpio.gz"


### PR DESCRIPTION
### Test with:

```
curl -fLO https://raw.githubusercontent.com/bohanyang/debi/force-lowmem/debi.sh && chmod a+rx debi.sh
```

### Solution for #45: Force low memory level 1 for machines have memory < 512M
```
--force-lowmem 1
```

### Other usages:
```
# Force disable low memory mode (USE AT YOUR OWN RISK)
--force-lowmem 0

# (useless)
--force-lowmem 2
```