### PR TITLE
fix: correct Debian version mapping for Trixie

### DIFF
--- a/debi.sh
+++ b/debi.sh
@@ -156,7 +156,7 @@ set_debian_version() {
             set_suite bookworm
             ;;
         13|trixie|testing)
-            set_suite bookworm
+            set_suite trixie
             ;;
         sid|unstable)
             set_suite sid


### PR DESCRIPTION
This pull request fixes the issue where using --version 13 incorrectly pointed the suite to Bookworm. The suite should be directed to Trixie instead.