### PR TITLE
fix: debian 11 backports is in archive and can block installation

### DIFF
--- a/debi.sh
+++ b/debi.sh
@@ -594,7 +594,7 @@ apt_components=main
 [ "$apt_non_free_firmware" = true ] && apt_components="$apt_components non-free-firmware"
 
 apt_services=updates
-[ "$apt_backports" = true ] && apt_services="$apt_services, backports"
+[ "$apt_backports" = true ] && has_backports && apt_services="$apt_services, backports"
 
 installer_directory="/boot/debian-$suite"
 


### PR DESCRIPTION
关联  #144  #146

对于 D11，D12，实际可以通过 archive.debian.org 访问

然而，考虑到用户可能用各种不同 mirror，而 mirror 未必有 backports，代码复杂度很高。
我只是把 D11 D12 的 backports 直接给禁了