### PR TITLE
fix: azure 缺少磁盘驱动

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -171,7 +171,7 @@ sudo reboot
 | `--cloud-kernel` | *標準* | クラウド最適化カーネルを使用 |
 | `--bpo-kernel` | *stable* | backportsから新しいカーネルを使用 |
 | `--firmware` | *自動検出* | ハードウェア用のnon-freeファームウェアを含める |
-| `--hyperv-pci-hotfix` | *無効* | インストーラー内核に一致する Debian kernel パッケージをダウンロードして initrd に組み込み、インストーラー起動初期に `pci-hyperv.ko` を読み込む（Azure NVMe / Hyper-V vPCI のディスク検出向け） |
+| `--hyperv-pci-hotfix` | *無効* | インストーラーのカーネルに一致する Debian kernel パッケージをダウンロードして initrd に組み込み、インストーラー起動初期に `pci-hyperv.ko` を読み込む（Azure NVMe / Hyper-V vPCI のディスク検出向け） |
 
 ### 詳細オプション
 

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -171,6 +171,7 @@ sudo reboot
 | `--cloud-kernel` | *標準* | クラウド最適化カーネルを使用 |
 | `--bpo-kernel` | *stable* | backportsから新しいカーネルを使用 |
 | `--firmware` | *自動検出* | ハードウェア用のnon-freeファームウェアを含める |
+| `--hyperv-pci-hotfix` | *無効* | インストーラー内核に一致する Debian kernel パッケージをダウンロードして initrd に組み込み、インストーラー起動初期に `pci-hyperv.ko` を読み込む（Azure NVMe / Hyper-V vPCI のディスク検出向け） |
 
 ### 詳細オプション
 
@@ -319,6 +320,12 @@ sudo ./debi.sh --ip YOUR_IP/CIDR --gateway YOUR_GATEWAY
 
 ```bash
 sudo ./debi.sh --firmware
+```
+
+**インストーラーで Azure NVMe ディスクを検出できない場合（Hyper-V vPCI）:**
+
+```bash
+sudo ./debi.sh --hyperv-pci-hotfix
 ```
 
 **インストールのデバッグ:**

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ sudo reboot
 | `--cloud-kernel` | *standard* | Use cloud-optimized kernel |
 | `--bpo-kernel` | *stable* | Use newer kernel from backports |
 | `--firmware` | *auto-detect* | Include non-free firmware for hardware |
+| `--hyperv-pci-hotfix` | *disabled* | Download the matching Debian kernel package, embed it in the installer initrd, and load `pci-hyperv.ko` during installer startup (useful for Azure NVMe/Hyper-V vPCI disk detection) |
 
 ### Advanced Options
 | Option | Default | Description |
@@ -292,6 +293,11 @@ sudo ./debi.sh --ip YOUR_IP/CIDR --gateway YOUR_GATEWAY
 **Need firmware for network card:**
 ```bash
 sudo ./debi.sh --firmware
+```
+
+**Azure NVMe disk not detected in installer (Hyper-V vPCI):**
+```bash
+sudo ./debi.sh --hyperv-pci-hotfix
 ```
 
 **Installation debugging:**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -173,6 +173,7 @@ sudo reboot
 | `--cloud-kernel` | *标准内核* | 使用为云环境优化的内核 |
 | `--bpo-kernel` | *稳定版内核* | 使用来自 backports 的较新内核 |
 | `--firmware` | *自动检测* | 为硬件安装 non-free 固件 |
+| `--hyperv-pci-hotfix` | *禁用* | 下载与安装器内核匹配的 Debian kernel 包，将其写入安装器 initrd，并在安装器启动早期加载 `pci-hyperv.ko`（适用于 Azure NVMe / Hyper-V vPCI 磁盘识别） |
 
 ### 高级选项
 
@@ -323,6 +324,12 @@ sudo ./debi.sh --ip YOUR_IP/CIDR --gateway YOUR_GATEWAY
 sudo ./debi.sh --firmware
 ```
 
+**Azure NVMe 磁盘在安装器中无法识别（Hyper-V vPCI）：**
+
+```bash
+sudo ./debi.sh --hyperv-pci-hotfix
+```
+
 **安装过程调试：**
 
 ```bash
@@ -354,4 +361,3 @@ sudo ./debi.sh --network-console --authorized-keys-url YOUR_KEYS_URL
 *作者 [@bohanyang](https://github.com/bohanyang) • [问题反馈](https://github.com/bohanyang/debi/issues) • [GitHub 仓库](https://github.com/bohanyang/debi)*
 
 </div>
-

--- a/debi.sh
+++ b/debi.sh
@@ -89,6 +89,120 @@ download() {
     fi
 }
 
+find_kernel_package() {
+    local package_name filename
+
+    package_name="linux-image-$1"
+    filename=$(
+        gzip -dc "$2" | awk -v pkg="$package_name" '
+            BEGIN { RS = ""; FS = "\n" }
+            $1 == "Package: " pkg {
+                for (i = 1; i <= NF; i++) {
+                    if ($i ~ /^Filename: /) {
+                        sub(/^Filename: /, "", $i)
+                        print $i
+                        exit
+                    }
+                }
+            }
+        '
+    )
+    [ -n "$filename" ] && {
+        printf '%s\n' "$filename"
+        return 0
+    }
+
+    package_name="linux-image-$1-unsigned"
+    filename=$(
+        gzip -dc "$2" | awk -v pkg="$package_name" '
+            BEGIN { RS = ""; FS = "\n" }
+            $1 == "Package: " pkg {
+                for (i = 1; i <= NF; i++) {
+                    if ($i ~ /^Filename: /) {
+                        sub(/^Filename: /, "", $i)
+                        print $i
+                        exit
+                    }
+                }
+            }
+        '
+    )
+    [ -n "$filename" ] && printf '%s\n' "$filename"
+}
+
+find_installer_kernel_version() {
+    cpio -it -F "$1" 2> /dev/null |
+    sed -n 's#^lib/modules/\([^/]*\)/.*#\1#p' |
+    sort -u |
+    head -n 1
+}
+
+inject_hyperv_pci_hotfix() {
+    local initrd_file installer_kernel_version packages_url package_path tmpdir
+
+    initrd_file=$1
+    installer_kernel_version=$(find_installer_kernel_version "$initrd_file")
+    [ -n "$installer_kernel_version" ] ||
+    err "Could not determine the installer kernel version from $initrd_file"
+
+    tmpdir=$(mktemp -d)
+    packages_url="$mirror_protocol://$mirror_host$mirror_directory/dists/$suite/main/binary-$architecture/Packages.gz"
+    download "$packages_url" "$tmpdir/Packages.gz"
+
+    package_path=$(find_kernel_package "$installer_kernel_version" "$tmpdir/Packages.gz" || true)
+    [ -n "$package_path" ] || {
+        rm -rf "$tmpdir"
+        err "Could not find a Debian kernel package for installer kernel $installer_kernel_version"
+    }
+
+    mkdir -p \
+        "$tmpdir/hotfix/debi-hyperv-pci" \
+        "$tmpdir/hotfix/lib/debian-installer-startup.d"
+    download "$mirror_protocol://$mirror_host$mirror_directory/$package_path" "$tmpdir/hotfix/debi-hyperv-pci/kernel.deb"
+    chmod 0644 "$tmpdir/hotfix/debi-hyperv-pci/kernel.deb"
+
+    cat > "$tmpdir/hotfix/lib/debian-installer-startup.d/S25pci-hyperv-hotfix" << EOF
+#!/bin/sh
+set -eu
+
+kernel_version=$installer_kernel_version
+module_path="/lib/modules/\$kernel_version/kernel/drivers/pci/controller/pci-hyperv.ko"
+package_path=/debi-hyperv-pci/kernel.deb
+tmpdir=
+
+cleanup() {
+    [ -n "\$tmpdir" ] && rm -rf "\$tmpdir"
+}
+
+trap cleanup EXIT INT TERM
+
+modprobe pci_hyperv_intf 2> /dev/null || true
+
+if [ ! -f "\$module_path" ]; then
+    tmpdir=\$(mktemp -d /tmp/debi-hv-pci.XXXXXX) || exit 0
+    data_member=\$(ar t "\$package_path" 2> /dev/null | awk '/^data\\.tar\\./ { print; exit }')
+    ar p "\$package_path" "\$data_member" > "\$tmpdir/\$data_member" 2> /dev/null || exit 0
+    mkdir -p "\$tmpdir/extract" "\$(dirname "\$module_path")"
+    xzcat "\$tmpdir/\$data_member" | tar -xf - -C "\$tmpdir/extract" "./lib/modules/\$kernel_version/kernel/drivers/pci/controller/pci-hyperv.ko" 2> /dev/null || exit 0
+    cp -f "\$tmpdir/extract/lib/modules/\$kernel_version/kernel/drivers/pci/controller/pci-hyperv.ko" "\$module_path" || exit 0
+    chmod 0644 "\$module_path" || exit 0
+fi
+
+modprobe pci_hyperv 2> /dev/null || insmod "\$module_path" 2> /dev/null || true
+EOF
+    chmod 0755 "$tmpdir/hotfix/lib/debian-installer-startup.d/S25pci-hyperv-hotfix"
+
+    (
+        cd "$tmpdir/hotfix"
+        find debi-hyperv-pci lib | cpio -o -H newc -A -F "$initrd_file" > /dev/null 2>&1
+    ) || {
+        rm -rf "$tmpdir"
+        err 'Could not append the Hyper-V PCI hotfix to the installer initrd'
+    }
+
+    rm -rf "$tmpdir"
+}
+
 # Set "$mirror_proxy" with "$http/https/ftp_proxy"
 # only when it is empty and one of those is not empty
 set_mirror_proxy() {
@@ -268,6 +382,7 @@ hold=false
 power_off=false
 architecture=
 firmware=false
+hyperv_pci_hotfix=false
 force_efi_extra_removable=true
 grub_timeout=5
 dry_run=false
@@ -523,6 +638,9 @@ while [ $# -gt 0 ]; do
             ;;
         --firmware)
             firmware=true
+            ;;
+        --hyperv-pci-hotfix)
+            hyperv_pci_hotfix=true
             ;;
         --no-force-efi-extra-removable)
             force_efi_extra_removable=false
@@ -948,6 +1066,7 @@ save_grub_cfg='cat'
     [ "$firmware" = true ] && download "$firmware_url" firmware.cpio.gz
 
     gzip -d initrd.gz
+    [ "$hyperv_pci_hotfix" = true ] && inject_hyperv_pci_hotfix "$PWD/initrd"
     # cpio reads a list of file names from the standard input
     echo preseed.cfg | cpio -o -H newc -A -F initrd
 


### PR DESCRIPTION
新增可选参数 `--hyperv-pci-hotfix`，用于处理 Azure NVMe / Hyper-V vPCI 场景下 installer 无法识别系统盘的问题。

开启后会在生成 installer 时，提前下载与 installer 内核匹配的 Debian kernel 包，并将该包写入 installer initrd。
同时写入一个 installer 启动早期执行的 startup hook，在 installer 环境内本地解包该 kernel 包，提取并加载 `pci-hyperv.ko`。

理论上讲没有副作用，就算不是 azure/不需要这个驱动，也可以使用这个 arg

关联 issue #143 